### PR TITLE
add_S3_hca_tags utility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/checksumming_io"]
+	path = bin/checksumming_io
+	url = git@github.com:HumanCellAtlas/checksumming_io.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "bin/checksumming_io"]
 	path = bin/checksumming_io
-	url = git@github.com:HumanCellAtlas/checksumming_io.git
+	url = https://github.com/HumanCellAtlas/checksumming_io.git

--- a/bin/add_s3_hca_tags.py
+++ b/bin/add_s3_hca_tags.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3.6
+
+import mimetypes
+from checksumming_io.checksumming_io import ChecksummingSink
+from s3_examples import S3ExampleBundle, S3ExampleFile
+
+
+class AddS3HcaTags:
+
+    CHECKSUM_TAGS = ['hca-dss-sha1', 'hca-dss-sha256', 'hca-dss-crc32c', 'hca-dss-s3_etag']
+    MIME_TAG = 'hca-dss-content-type'
+
+    def __init__(self):
+        self.run()
+
+    def run(self):
+        for bundle in S3ExampleBundle.all():
+            print("Bundle: ", bundle.path)
+            self.add_tagging_for_bundle(bundle)
+
+    def add_tagging_for_bundle(self, bundle: S3ExampleBundle):
+        for file in bundle.files:
+            print("    File: ", file.path)
+            self.add_tagging_for_file(file)
+
+    def add_tagging_for_file(self, file: S3ExampleFile):
+        current_tags = file.get_tagging()
+        new_tags = {}
+        new_tags.update(self.additional_checksum_tags(file, current_tags))
+        new_tags.update(self.additional_mime_tags(file, current_tags))
+        if new_tags:
+            print("        Adding tags: ", list(new_tags.keys()))
+            all_tags = dict(current_tags, **new_tags)
+            file.add_tagging(all_tags)
+
+    def additional_checksum_tags(self, file: S3ExampleFile, current_tags: dict):
+        if self.checksum_tags_are_all_present(current_tags):
+            return {}
+        else:
+            sums = self.compute_checksums(file)
+            return {
+                'hca-dss-s3_etag': sums['s3_etag'],
+                'hca-dss-sha1':    sums['sha1'],
+                'hca-dss-sha256':  sums['sha256'],
+                'hca-dss-crc32c':  sums['crc32c'],
+            }
+
+    def additional_mime_tags(self, file: S3ExampleFile, current_tags: dict):
+        if 'content-type' in current_tags:
+            return {}
+        else:
+            return {'content-type': mimetypes.guess_type(file.path)[0]}
+
+    def checksum_tags_are_all_present(self, actual_tags: dict) -> bool:
+        # TODO try python has map(), filter(), reduce(), all()
+        tags_present = [tag for tag in self.CHECKSUM_TAGS if tag in actual_tags.keys()]
+        return len(tags_present) == len(self.CHECKSUM_TAGS)
+
+    @staticmethod
+    def compute_checksums(file: S3ExampleFile) -> dict:
+        with ChecksummingSink() as sink:
+            file.s3object().download_fileobj(sink)
+            return sink.get_checksums()
+
+if __name__ == '__main__':
+    AddS3HcaTags()

--- a/bin/s3_examples/__init__.py
+++ b/bin/s3_examples/__init__.py
@@ -1,0 +1,6 @@
+"""
+Classes that interact with the example data bundles in S3
+"""
+
+from .s3_example_bundle import S3ExampleBundle
+from .s3_example_file import S3ExampleFile

--- a/bin/s3_examples/s3_example_bundle.py
+++ b/bin/s3_examples/s3_example_bundle.py
@@ -1,0 +1,31 @@
+import uuid
+import boto3
+from .s3_example_file import S3ExampleFile
+
+
+class S3ExampleBundle:
+
+    BUNDLE_EXAMPLES_BUCKET = 'hca-dss-test-src'
+    BUNDLE_EXAMPLES_ROOT = 'data-bundle-examples'
+    BUNDLE_EXAMPLES_BUNDLE_LIST_PATH = f"{BUNDLE_EXAMPLES_ROOT}/import/bundle_list"
+
+    s3 = boto3.resource('s3')
+    _examples_s3_bucket = s3.Bucket(BUNDLE_EXAMPLES_BUCKET)
+
+    def __init__(self, bundle_path):
+        self.bucket = self._examples_s3_bucket
+        self.path = bundle_path
+        self.uuid = str(uuid.uuid4())
+        self.files = self._get_s3_files()
+
+    @classmethod
+    def all(cls):
+        bundle_list_s3object = cls._examples_s3_bucket.Object(cls.BUNDLE_EXAMPLES_BUNDLE_LIST_PATH)
+        bundle_list = bundle_list_s3object.get()['Body'].read().decode('utf-8').split("\n")
+        for bundle_path in bundle_list:
+            yield cls(bundle_path)
+
+    def _get_s3_files(self):
+        bundle_folder_path = f"{self.BUNDLE_EXAMPLES_ROOT}/{self.path}"
+        object_summaries = self._examples_s3_bucket.objects.filter(Prefix=bundle_folder_path)
+        return [S3ExampleFile(objectSummary, self) for objectSummary in object_summaries]

--- a/bin/s3_examples/s3_example_file.py
+++ b/bin/s3_examples/s3_example_file.py
@@ -1,0 +1,43 @@
+import uuid
+from functools import reduce
+import boto3
+
+
+class S3ExampleFile:
+    def __init__(self, object_summary, bundle):
+        self.s3_object_summary = object_summary
+        self.bundle = bundle
+        self.path = object_summary.key
+        self.url = f"s3://{bundle.BUNDLE_EXAMPLES_BUCKET}/{self.path}"
+        self.timestamp = object_summary.last_modified
+        self.uuid = str(uuid.uuid4())
+
+    def s3object(self):
+        return self.bundle.bucket.Object(self.path)
+
+    def get_tagging(self):
+        s3client = self.bundle.s3.meta.client
+        response = s3client.get_object_tagging(Bucket=self.s3_object_summary.bucket_name,
+                                               Key=self.s3_object_summary.key)
+        return self._decode_tags(response['TagSet'])
+
+    def add_tagging(self, tags: dict):
+        s3client = self.bundle.s3.meta.client
+        tagging = dict(TagSet=self._encode_tags(tags))
+        s3client.put_object_tagging(Bucket=self.s3_object_summary.bucket_name,
+                                    Key=self.s3_object_summary.key,
+                                    Tagging=tagging)
+
+    # tags = [{'Key': 'a', 'Value': '1'}, {'Key': 'b', 'Value': '2'}]
+    # simplified_dicts = [{'a': '1'}, {'b': '2'}]
+    # returns {'a': '1', 'b': '2'}
+    @staticmethod
+    def _decode_tags(tags):
+        if not tags:
+            return {}
+        simplified_dicts = list({tag['Key']: tag['Value']} for tag in tags)
+        return reduce(lambda x, y: dict(x, **y), simplified_dicts)
+
+    @staticmethod
+    def _encode_tags(tags):
+        return [dict(Key=k, Value=v) for k, v in tags.items()]


### PR DESCRIPTION
A utility to examine all the bundles in import/bundle_list and add any missing HCA tags: 'hca-dss-s3_etag', 'hca-dss-sha1', 'hca-dss-sha256', 'hca-dss-crc32c', 'content-type'